### PR TITLE
Replace function call removed in PAPI v6 with an equivalent one

### DIFF
--- a/src/event_set.rs
+++ b/src/event_set.rs
@@ -539,7 +539,7 @@ impl<'p> EventSetBuilder<'p> {
         if num_events < 0 {
             check(num_events)?;
         }
-        let num_counters = unsafe { ffi::PAPI_num_counters() };
+        let num_counters = unsafe { ffi::PAPI_num_cmp_hwctrs(0) };
         if num_counters < 0 {
             check(num_counters)?;
         } else if num_events == num_counters {


### PR DESCRIPTION
Fixes #1.

According to the documentation, the now missing `PAPI_num_counters` function returns the "number of hardware counters supported by the current CPU component".

This PR replaces the call to that with a call to `PAPI_num_cmp_hwctrs` (which still exists in the current version). This should be equivalent, as, according to the documentation:

> PAPI_num_cmp_hwctrs() returns the number of counters present in the specified component. 
> By convention, component 0 is always the cpu. 